### PR TITLE
Fix crash when 'urlStr' is empty

### DIFF
--- a/SwiftPamphletApp/FundationFunction.swift
+++ b/SwiftPamphletApp/FundationFunction.swift
@@ -33,7 +33,11 @@ extension Array {
 
 // 跳到浏览器中显示网址内容
 func gotoWebBrowser(urlStr: String) {
-    NSWorkspace.shared.open(URL(string: urlStr)!)
+    if !urlStr.isEmpty {
+        NSWorkspace.shared.open(URL(string: urlStr)!)
+    } else {
+        print("error: url is empty!")
+    }
 }
 
 // 从Bundle中读取并解析JSON文件生成Model

--- a/SwiftPamphletApp/FundationFunction.swift
+++ b/SwiftPamphletApp/FundationFunction.swift
@@ -34,10 +34,21 @@ extension Array {
 // 跳到浏览器中显示网址内容
 func gotoWebBrowser(urlStr: String) {
     if !urlStr.isEmpty {
-        NSWorkspace.shared.open(URL(string: urlStr)!)
+        let validUrlStr = validHTTPUrlStrFromUrlStr(urlStr: urlStr)
+        NSWorkspace.shared.open(URL(string: validUrlStr)!)
     } else {
         print("error: url is empty!")
     }
+}
+
+// 检查地址是否有效
+func validHTTPUrlStrFromUrlStr(urlStr: String) -> String {
+    let httpPrefix = "http://"
+    let httpsPrefix = "https://"
+    if (urlStr.hasPrefix(httpPrefix) || urlStr.hasPrefix(httpsPrefix)) {
+        return urlStr
+    }
+    return httpsPrefix + urlStr
 }
 
 // 从Bundle中读取并解析JSON文件生成Model

--- a/SwiftPamphletApp/GItHubAPI/DetailView/UserView.swift
+++ b/SwiftPamphletApp/GItHubAPI/DetailView/UserView.swift
@@ -34,8 +34,10 @@ struct UserView: View {
                 }
                 HStack {
                     if vm.user.blog != nil {
-                        Text("博客：\(vm.user.blog ?? "")")
-                        ButtonGoGitHubWeb(url: vm.user.blog ?? "", text: "访问")
+                        if !vm.user.blog!.isEmpty {
+                            Text("博客：\(vm.user.blog ?? "")")
+                            ButtonGoGitHubWeb(url: vm.user.blog ?? "", text: "访问")
+                        }
                     }
                     if vm.user.twitterUsername != nil {
                         Text("Twitter：")


### PR DESCRIPTION
Some authors' blog address is not exist. Then it will crash if force unwrapping  the 'urlStr

<img width="423" alt="iShot2021-11-25 01 21 04" src="https://user-images.githubusercontent.com/15107116/143285717-e40d9e19-1483-4867-9a4b-28fe853df0aa.png">

