### PR TITLE
Add workflow to build package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Release
+name: Build Package
 on: [push, pull_request, workflow_dispatch]
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: snickerbockers/submodules-init@v4
       - name: Import PAT from Actions secrets
         env:
-          PAT: ${{ secrets.SECRET_KEY }}
+          PAT: ${{ secrets.PAT }}
         run: |
          cd SwiftPamphletApp
          sed -i '' s/'gitHubAccessToken = ""'/'gitHubAccessToken = "$PAT"'/ SwiftPamphletAppConfig.swift

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,9 @@ jobs:
         run: |
           chmod +x ./compile.command
           /bin/bash -c ./compile.command
-      - name: Upload .app
+          zip -r9 戴铭的Swift小册子.zip 戴铭的Swift小册子.app
+      - name: Upload App.zip
         uses: actions/upload-artifact@v2.2.4
         with:
-          name: "戴铭的Swift小册子.app"
-          path: "戴铭的Swift小册子.app"
+          name: "戴铭的Swift小册子.zip"
+          path: "戴铭的Swift小册子.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,9 @@ jobs:
       - name: submodules-init
         uses: snickerbockers/submodules-init@v4
       - name: Import PAT from Actions secrets
-        env:
-          PAT: ${{ secrets.PAT }}
         run: |
          cd SwiftPamphletApp
-         sed -i '' s/'gitHubAccessToken = ""'/'gitHubAccessToken = "$PAT"'/ SwiftPamphletAppConfig.swift
+         sed -i '' s/'gitHubAccessToken = ""'/'gitHubAccessToken = "${{ secrets.PAT }}"'/ SwiftPamphletAppConfig.swift
          cd ..
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build Release
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - name: submodules-init
+        uses: snickerbockers/submodules-init@v4
+      - name: Import PAT from Actions secrets
+        env:
+          PAT: ${{ secrets.SECRET_KEY }}
+        run: |
+         cd SwiftPamphletApp
+         sed -i '' s/'gitHubAccessToken = ""'/'gitHubAccessToken = "$PAT"'/ SwiftPamphletAppConfig.swift
+         cd ..
+      - name: Build
+        run: |
+          chmod +x ./compile.command
+          /bin/bash -c ./compile.command
+      - name: Upload .app
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: "戴铭的Swift小册子.app"
+          path: "戴铭的Swift小册子.app"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 记得以前 PHP 有个 chm 的手册，写的很简单，但很全，每个知识点都有例子，社区版每个知识点下面还有留言互动。因此，我弄了个 Swift 的手册，是个 macOS 程序。建议使用我开发的这个 macOS 程序来浏览，使用方法是：
 * 从  [GitHub - ming1016/SwiftPamphletApp: 戴铭的 Swift 小册子，一本活的 Swift 手册](https://github.com/ming1016/SwiftPamphletApp)  仓库拉代码。
 * 然后在 SwiftPamphletAppConfig.swift 里 gitHubAccessToken 加入你的 GitHub Access Token。GitHub Access Token 在  [Personal Access Tokens](https://github.com/settings/tokens)  这里获取，scope 勾上 repo 和 user。
-* 使用Xcode编译生成这个手册程序。Xcode 和 macOS 都需要升到最新版，如果遇到 swift package 下载不下来的情况，参看这个议题来解决：[请问markdownui一直更新不下来是什么原因 · Issue #88 · ming1016/SwiftPamphletApp · GitHub](https://github.com/ming1016/SwiftPamphletApp/issues/88)
+* 使用Xcode编译生成这个手册程序或是连点两下compile.command。Xcode 和 macOS 都需要升到最新版，如果遇到 swift package 下载不下来的情况，参看这个议题来解决：[请问markdownui一直更新不下来是什么原因 · Issue #88 · ming1016/SwiftPamphletApp · GitHub](https://github.com/ming1016/SwiftPamphletApp/issues/88)
 
 截图如下：
 ![01](https://user-images.githubusercontent.com/251980/142998258-0f44f4fe-e113-4428-b381-be7e4eb5a899.png)


### PR DESCRIPTION
Requirea storaging PAT to actions secrets and name it as PAT
while project update ,user won't need to compile manually in local, only need to fetch and merge commits and wait for about 3 minutes then download it
NOTE: please add instructions to readme that remind users to storage their PAT to actions secrets if this get merged


<img width="1436" alt="截圖 2021-12-18 下午2 22 12" src="https://user-images.githubusercontent.com/72635554/146632558-1a82d673-6774-40f0-90cc-0c525bbf2562.png">
<img width="1416" alt="截圖 2021-12-18 下午2 56 45" src="https://user-images.githubusercontent.com/72635554/146632560-359eafb5-a9f9-4232-a60a-b3414cb90e48.png">

