### PR TITLE
build(build.yml): 指定 Github Action  Workflow 打包时使用最新稳定版的 xcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@master
       - uses: actions/checkout@v2


### PR DESCRIPTION
不指定的话，使用 Github Action 的自动云打包功能会始终失败，详见 #199 