### PR TITLE
Update workflow action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ jobs:
           xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
-      - name: submodules-init
-        uses: snickerbockers/submodules-init@v4
+          submodules: recursive
       - name: Import PAT from Actions secrets
         run: |
          cd SwiftPamphletApp/App

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
           xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
-          submodules: recursive
+          with:
+            submodules: recursive
       - name: Import PAT from Actions secrets
         run: |
          cd SwiftPamphletApp/App

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
           xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
-          with:
-            submodules: recursive
+        with:
+          submodules: recursive
       - name: Import PAT from Actions secrets
         run: |
          cd SwiftPamphletApp/App

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           /bin/bash -c ./compile.command
           zip -r9 戴铭的开发小册子.zip 戴铭的开发小册子.app
       - name: Upload App.zip
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           name: "戴铭的开发小册子.zip"
           path: "戴铭的开发小册子.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ jobs:
         with:
           xcode-version: latest-stable
       - name: Checkout
-        uses: actions/checkout@master
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: submodules-init
         uses: snickerbockers/submodules-init@v4
       - name: Import PAT from Actions secrets


### PR DESCRIPTION
针对当前 action workflow 里使用 action 版本过低（主要是action所指定依赖的 node 版本过低）导致的 action 流程结果告警进行了 action 版本升级/更换，使其适配 GitHub action 当前默认的最新的 node20 环境